### PR TITLE
Plumb through a list of key-value pair options to the ffmpeg demuxer

### DIFF
--- a/src/Bufdio/Decoders/FFmpeg/FFmpegDecoderOptions.cs
+++ b/src/Bufdio/Decoders/FFmpeg/FFmpegDecoderOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Bufdio.Decoders.FFmpeg
+﻿using System.Collections.Generic;
+
+namespace Bufdio.Decoders.FFmpeg
 {
     /// <summary>
     /// Options for decoding (and, or) resampling specified audio source that can be passed
@@ -11,10 +13,12 @@
         /// </summary>
         /// <param name="channels">Desired audio channel count.</param>
         /// <param name="sampleRate">Desired audio sample rate.</param>
-        public FFmpegDecoderOptions(int channels = 2, int sampleRate = 44100)
+        /// <param name="demuxerOptions">Options passed to the demuxer.</param>
+        public FFmpegDecoderOptions(int channels = 2, int sampleRate = 44100, IReadOnlyDictionary<string, string> demuxerOptions = null)
         {
             Channels = channels;
             SampleRate = sampleRate;
+            DemuxerOptions = demuxerOptions;
         }
 
         /// <summary>
@@ -26,5 +30,10 @@
         /// Gets destination audio sample rate.
         /// </summary>
         public int SampleRate { get; }
+
+        /// <summary>
+        /// Gets the options which are passed to the demuxer.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> DemuxerOptions { get; }
     }
 }

--- a/src/Bufdio/Players/IAudioPlayer.cs
+++ b/src/Bufdio/Players/IAudioPlayer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Bufdio.Players
@@ -74,13 +75,15 @@ namespace Bufdio.Players
         /// Loads audio from specified URL to the player. The URL might be HTTP URL or local file path.
         /// </summary>
         /// <param name="url">Audio URL or audio file path.</param>
-        void Load(string url);
+        /// <param name="options">Options for loading the audio file.</param>
+        void Load(string url, IReadOnlyDictionary<string, string> options = null);
 
         /// <summary>
         /// Loads audio stream to the player.
         /// </summary>
         /// <param name="stream">Source audio stream.</param>
-        void Load(Stream stream);
+        /// <param name="options">Options to pass when loading the audio file.</param>
+        void Load(Stream stream, IReadOnlyDictionary<string, string> options = null);
 
         /// <summary>
         /// Starts audio playback.


### PR DESCRIPTION
I stumbled across the library and it seemed like it would be pretty useful, but for my scenario, I needed a way to set some specific demuxer options (see [here](https://ffmpeg.org/ffmpeg-formats.html#Demuxers) for examples).

To that end, I added an optional parameter when loading a file to pass a set of key-value pairs that eventually get passed to `avformat_open_input`, and figured I'd share the changes if you find them useful.